### PR TITLE
Fix sdram size

### DIFF
--- a/bsp/radiona/ulx3s/smp/README.md
+++ b/bsp/radiona/ulx3s/smp/README.md
@@ -28,9 +28,10 @@ saxon_standalone_compile sdramInit CFLAGS_ARGS="-DSDRAM_TIMING=MT48LC16M16A2_6A_
 saxon_openocd
 ```
 
-Customize SDRAM_SIZE or FPGA_SIZE
+Customize SDRAM_SIZE and FPGA_SIZE for blue ULX3S board with 85F and 64Mb SDRAM
 
 ```sh
+saxon_standalone_compile bootloader CFLAGS_ARGS="-DSDRAM_TIMING=AS4C32M16SB_7TCN_ps"
 SDRAM_SIZE=64 saxon_netlist
 FPGA_SIZE=85 saxon_bitstream
 ```

--- a/bsp/radiona/ulx3s/smp/README.md
+++ b/bsp/radiona/ulx3s/smp/README.md
@@ -28,6 +28,13 @@ saxon_standalone_compile sdramInit CFLAGS_ARGS="-DSDRAM_TIMING=MT48LC16M16A2_6A_
 saxon_openocd
 ```
 
+Customize SDRAM_SIZE or FPGA_SIZE
+
+```sh
+SDRAM_SIZE=64 saxon_netlist
+FPGA_SIZE=85 saxon_bitstream
+```
+
 Flash SPI 
 
 ```sh

--- a/bsp/radiona/ulx3s/smp/source.sh
+++ b/bsp/radiona/ulx3s/smp/source.sh
@@ -21,7 +21,7 @@ source $SAXON_BSP_COMMON_SCRIPTS/buildroot.sh
 
 saxon_netlist(){
   cd $SAXON_ROOT/SaxonSoc
-  sbt "runMain saxon.board.radiona.ulx3s.Ulx3sSmp"
+  sbt "runMain saxon.board.radiona.ulx3s.Ulx3sSmp $SDRAM_SIZE"
 }
 
 saxon_bitstream(){


### PR DESCRIPTION
Pass SDRAM_SIZE to saxon_netlist and example how to use it.

This is needed to fully support blue ULX3S board with 85F and 64Mb of SDRAM